### PR TITLE
add parse, generate, pretty_generate, fast_generate methods (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Legion::JSON
 
+## [1.3.0] - 2026-03-26
+
+### Added
+- `.parse(string, symbolize_names: true)` — wraps `::JSON.parse` with `ParseError` error handling and symbol keys by default
+- `.generate(object)` — wraps `::JSON.generate` for compact output
+- `.pretty_generate(object)` — wraps `::JSON.pretty_generate` for formatted output
+- `.fast_generate(object)` — wraps `::JSON.fast_generate` for unchecked fast output
+- Helper methods: `json_parse`, `json_generate`, `json_pretty_generate` in `Legion::JSON::Helper`
+
 ## [1.2.1] - 2026-03-22
 
 ### Added

--- a/lib/legion/json.rb
+++ b/lib/legion/json.rb
@@ -25,5 +25,27 @@ module Legion
       parser.dump(object, pretty: pretty)
     end
     module_function :dump
+
+    def parse(string, symbolize_names: true)
+      ::JSON.parse(string, symbolize_names: symbolize_names)
+    rescue ::JSON::ParserError => e
+      raise Legion::JSON::ParseError.build(e, string)
+    end
+    module_function :parse
+
+    def generate(object)
+      ::JSON.generate(object)
+    end
+    module_function :generate
+
+    def pretty_generate(object)
+      ::JSON.pretty_generate(object)
+    end
+    module_function :pretty_generate
+
+    def fast_generate(object)
+      ::JSON.fast_generate(object)
+    end
+    module_function :fast_generate
   end
 end

--- a/lib/legion/json.rb
+++ b/lib/legion/json.rb
@@ -28,7 +28,7 @@ module Legion
 
     def parse(string, symbolize_names: true)
       ::JSON.parse(string, symbolize_names: symbolize_names)
-    rescue ::JSON::ParserError => e
+    rescue StandardError => e
       raise Legion::JSON::ParseError.build(e, string)
     end
     module_function :parse

--- a/lib/legion/json/helper.rb
+++ b/lib/legion/json/helper.rb
@@ -10,6 +10,18 @@ module Legion
       def json_dump(object, pretty: false)
         Legion::JSON.dump(object, pretty: pretty)
       end
+
+      def json_parse(string, symbolize_names: true)
+        Legion::JSON.parse(string, symbolize_names: symbolize_names)
+      end
+
+      def json_generate(object)
+        Legion::JSON.generate(object)
+      end
+
+      def json_pretty_generate(object)
+        Legion::JSON.pretty_generate(object)
+      end
     end
   end
 end

--- a/lib/legion/json/helper.rb
+++ b/lib/legion/json/helper.rb
@@ -8,7 +8,8 @@ module Legion
       end
 
       def json_dump(object, pretty: false)
-        Legion::JSON.dump(object, pretty: pretty)
+        opts = { pretty: pretty }
+        Legion::JSON.dump(object, **opts)
       end
 
       def json_parse(string, symbolize_names: true)

--- a/lib/legion/json/version.rb
+++ b/lib/legion/json/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Json
-    VERSION = '1.2.1'
+    VERSION = '1.3.0'
   end
 end

--- a/spec/legion/json/helper_spec.rb
+++ b/spec/legion/json/helper_spec.rb
@@ -38,4 +38,39 @@ RSpec.describe Legion::JSON::Helper do
       expect(result).to include("\n")
     end
   end
+
+  describe '#json_parse' do
+    it 'parses JSON with symbolized keys by default' do
+      result = instance.json_parse('{"name":"test"}')
+      expect(result).to eq(name: 'test')
+    end
+
+    it 'returns string keys when requested' do
+      result = instance.json_parse('{"name":"test"}', symbolize_names: false)
+      expect(result).to eq('name' => 'test')
+    end
+
+    it 'raises ParseError on invalid JSON' do
+      expect { instance.json_parse('not json') }.to raise_error(Legion::JSON::ParseError)
+    end
+  end
+
+  describe '#json_generate' do
+    it 'serializes a hash to compact JSON' do
+      result = instance.json_generate({ name: 'test' })
+      expect(result).to eq('{"name":"test"}')
+    end
+  end
+
+  describe '#json_pretty_generate' do
+    it 'produces formatted output with newlines' do
+      result = instance.json_pretty_generate({ name: 'test' })
+      expect(result).to include("\n")
+    end
+
+    it 'produces valid JSON' do
+      result = instance.json_pretty_generate({ name: 'test' })
+      expect(instance.json_parse(result)).to eq(name: 'test')
+    end
+  end
 end

--- a/spec/legion/json_spec.rb
+++ b/spec/legion/json_spec.rb
@@ -201,9 +201,9 @@ RSpec.describe Legion::JSON do
 
     it 'includes original input in ParseError' do
       bad = '{"broken'
-      described_class.parse(bad)
-    rescue Legion::JSON::ParseError => e
-      expect(e.data).to eq(bad)
+      expect { described_class.parse(bad) }.to raise_error(Legion::JSON::ParseError) do |e|
+        expect(e.data).to eq(bad)
+      end
     end
 
     it 'round-trips with generate' do

--- a/spec/legion/json_spec.rb
+++ b/spec/legion/json_spec.rb
@@ -173,6 +173,99 @@ RSpec.describe Legion::JSON do
       end
     end
   end
+
+  describe '.parse' do
+    it 'parses JSON with symbolized keys by default' do
+      result = described_class.parse('{"foo":"bar"}')
+      expect(result).to eq(foo: 'bar')
+    end
+
+    it 'parses nested objects with symbolized keys' do
+      result = described_class.parse('{"outer":{"inner":"value"}}')
+      expect(result[:outer][:inner]).to eq('value')
+    end
+
+    it 'returns string keys when symbolize_names is false' do
+      result = described_class.parse('{"foo":"bar"}', symbolize_names: false)
+      expect(result).to eq('foo' => 'bar')
+    end
+
+    it 'parses arrays' do
+      result = described_class.parse('[1,"two",3]')
+      expect(result).to eq([1, 'two', 3])
+    end
+
+    it 'raises ParseError on invalid JSON' do
+      expect { described_class.parse('{bad}') }.to raise_error(Legion::JSON::ParseError)
+    end
+
+    it 'includes original input in ParseError' do
+      bad = '{"broken'
+      described_class.parse(bad)
+    rescue Legion::JSON::ParseError => e
+      expect(e.data).to eq(bad)
+    end
+
+    it 'round-trips with generate' do
+      original = { name: 'test', count: 5 }
+      json = described_class.generate(original)
+      result = described_class.parse(json)
+      expect(result).to eq(original)
+    end
+  end
+
+  describe '.generate' do
+    it 'serializes a hash to compact JSON' do
+      result = described_class.generate({ foo: 'bar' })
+      expect(result).to eq('{"foo":"bar"}')
+    end
+
+    it 'serializes an array' do
+      result = described_class.generate([1, 2, 3])
+      expect(result).to eq('[1,2,3]')
+    end
+
+    it 'produces compact output without newlines' do
+      result = described_class.generate({ a: 1, b: 2 })
+      expect(result).not_to include("\n")
+    end
+
+    it 'serializes nested structures' do
+      result = described_class.generate({ a: { b: [1, 2] } })
+      parsed = described_class.parse(result)
+      expect(parsed).to eq(a: { b: [1, 2] })
+    end
+  end
+
+  describe '.pretty_generate' do
+    it 'produces formatted output with newlines' do
+      result = described_class.pretty_generate({ foo: 'bar' })
+      expect(result).to include("\n")
+    end
+
+    it 'produces valid JSON that round-trips' do
+      original = { name: 'test', items: [1, 2] }
+      pretty = described_class.pretty_generate(original)
+      expect(described_class.parse(pretty)).to eq(original)
+    end
+
+    it 'produces indented output' do
+      result = described_class.pretty_generate({ foo: 'bar' })
+      expect(result).to include('  ')
+    end
+  end
+
+  describe '.fast_generate' do
+    it 'serializes a hash' do
+      result = described_class.fast_generate({ foo: 'bar' })
+      expect(described_class.parse(result)).to eq(foo: 'bar')
+    end
+
+    it 'serializes an array' do
+      result = described_class.fast_generate([1, 2, 3])
+      expect(described_class.parse(result)).to eq([1, 2, 3])
+    end
+  end
 end
 
 RSpec.describe Legion::JSON::ParseError do


### PR DESCRIPTION
## Summary
- Add `.parse`, `.generate`, `.pretty_generate`, `.fast_generate` to `Legion::JSON`, wrapping the full stdlib `::JSON` surface
- Add `json_parse`, `json_generate`, `json_pretty_generate` to `Legion::JSON::Helper`
- `.parse` defaults to `symbolize_names: true` (matches `.load` convention) and wraps errors in `ParseError`

Closes #2

## Changes
- `lib/legion/json.rb` — 4 new module methods delegating to `::JSON`
- `lib/legion/json/helper.rb` — 3 new helper instance methods
- `spec/legion/json_spec.rb` — 16 new examples (parse, generate, pretty_generate, fast_generate)
- `spec/legion/json/helper_spec.rb` — 6 new examples (json_parse, json_generate, json_pretty_generate)
- `lib/legion/json/version.rb` — bump to 1.3.0
- `CHANGELOG.md` — add 1.3.0 entry

## Test Coverage
- 72 examples, 0 failures
- 100% line coverage
- `bundle exec rubocop` — zero offenses