### PR TITLE
fix: dump pretty:false produces compact output with Oj adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::JSON
 
+## [1.3.3] - 2026-04-14
+
+### Fixed
+- `Legion::JSON.dump` with `pretty: false` (the default) produced pretty-printed output when Oj adapter was active. Oj/MultiJson treats any explicit `pretty:` keyword (even `false`) as truthy. Fix: only pass `pretty: true` when requested; omit the keyword entirely otherwise.
+
 ## [1.3.2] - 2026-04-08
 
 ### Fixed

--- a/lib/legion/json.rb
+++ b/lib/legion/json.rb
@@ -23,7 +23,8 @@ module Legion
 
     def dump(object = nil, pretty: false, **kwargs)
       data = object.nil? ? kwargs : object
-      parser.dump(data, pretty: pretty)
+      # Only pass pretty: when true — Oj/MultiJson treats any explicit pretty: (even false) as truthy
+      pretty ? parser.dump(data, pretty: true) : parser.dump(data)
     end
     module_function :dump
 

--- a/lib/legion/json/version.rb
+++ b/lib/legion/json/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Json
-    VERSION = '1.3.2'
+    VERSION = '1.3.3'
   end
 end


### PR DESCRIPTION
## Summary
- `Legion::JSON.dump` with `pretty: false` (the default) was producing pretty-printed output when Oj was the MultiJson adapter
- Oj/MultiJson treats any explicit `pretty:` keyword (even `false`) as truthy
- Fix: only pass `pretty: true` when requested; omit the keyword entirely otherwise
- This affected all `Legion::JSON.dump` callers across the ecosystem (every gem that serializes JSON)

## Found by
Fleet pipeline spool specs — JSONL files had multi-line entries instead of one-per-line

## Test plan
- 72 examples, 0 failures, 100% coverage
- 0 rubocop offenses